### PR TITLE
fixes #3 bug, better array matching support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: node_js
 node_js:
   - '0.10'
+  - '0.12'
+  - '1'
+  - '2'

--- a/.verb.md
+++ b/.verb.md
@@ -76,6 +76,16 @@ isMatch('b');
 //=> false
 ```
 
+**from an object:**
+
+```js
+var isMatch = matcher({a: 'b'});
+
+isMatch({a: 'b'}); //=> true
+isMatch({a: 'b', c: 'd'}); //=> false
+isMatch({e: 'f', c: 'd'}); //=> false
+```
+
 ## Related projects
 {%= related(['micromatch', 'is-glob']) %}
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # is-match [![NPM version](https://badge.fury.io/js/is-match.svg)](http://badge.fury.io/js/is-match)  [![Build Status](https://travis-ci.org/jonschlinkert/is-match.svg)](https://travis-ci.org/jonschlinkert/is-match)
 
-> Create a matching function from a glob pattern, regex, string, array or function.
+> Create a matching function from a glob pattern, regex, string, array, object or function.
 
 ## Install
 
@@ -79,6 +79,16 @@ isMatch('a');
 
 isMatch('b');
 //=> false
+```
+
+**from an object:**
+
+```js
+var isMatch = matcher({a: 'b'});
+
+isMatch({a: 'b'}); //=> true
+isMatch({a: 'b', c: 'd'}); //=> false
+isMatch({e: 'f', c: 'd'}); //=> false
 ```
 
 ## Related projects

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@
 'use strict';
 
 var deepEqual = require('deep-equal');
-var isObject = require('isobject');
+var isObject = require('is-extendable');
 var isGlob = require('is-glob');
 var mm = require('micromatch');
 
@@ -36,10 +36,17 @@ function isMatch(pattern, options) {
     };
   }
 
-  if (Array.isArray(pattern) || isObject(pattern)) {
+  if (Array.isArray(pattern)) {
+    return function (val) {
+      return mm(val, pattern, options).length !== 0;
+    };
+  }
+
+  if (isObject(pattern)) {
     return function (val) {
       return deepEqual(val, pattern);
     };
   }
-  throw new TypeError('isMatch expects a string, array, regex or function:', arguments);
+
+  throw new TypeError('isMatch expects a string, array, regex, object or function:', arguments);
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "is-match",
-  "description": "Create a matching function from a glob pattern, regex, string, array or function.",
+  "description": "Create a matching function from a glob pattern, regex, string, array, object or function.",
   "version": "0.3.3",
   "homepage": "https://github.com/jonschlinkert/is-match",
   "author": {

--- a/package.json
+++ b/package.json
@@ -27,14 +27,13 @@
   },
   "dependencies": {
     "deep-equal": "^1.0.0",
+    "is-extendable": "^0.1.1",
     "is-glob": "^2.0.0",
-    "isobject": "^1.0.0",
     "micromatch": "^2.1.6"
   },
   "devDependencies": {
     "mocha": "*",
-    "should": "*",
-    "verb": "^0.8.6"
+    "should": "*"
   },
   "keywords": [
     "any",

--- a/test.js
+++ b/test.js
@@ -29,10 +29,17 @@ describe('should return a matching function:', function () {
     matcher('a')('def').should.be.false;
   });
 
-  it('from a glob pattern:', function () {
+  it('from a string glob pattern:', function () {
     matcher('*')('a').should.be.true;
     matcher('!b')('a').should.be.true;
     matcher('!b')('b').should.be.false;
+  });
+
+  it('from a string non-glob pattern:', function () {
+    matcher('abc')('foo abc bar').should.be.false;
+    matcher('abc')('abc').should.be.true;
+    matcher('abc')(['foo', 'abc']).should.be.true;
+    matcher('abc')(['foo abc bar', 'baz']).should.be.true;
   });
 
   it('from an array of glob patterns:', function () {
@@ -41,6 +48,8 @@ describe('should return a matching function:', function () {
     matcher(['b', 'a'])(['a', 'b']).should.be.false;
     matcher(['b', 'a'])(['b', 'a']).should.be.true;
     matcher(['b', 'c', '*'])(['b', 'c', '*']).should.be.true;
+    matcher(['*-koaip', '!foo-koa'])('x-koaip').should.be.true;
+    matcher(['*-koaip', '!foo-koa'])(['foo-koa', 'bar-koa']).should.be.false;
   });
 
   it('from a regex:', function () {

--- a/test.js
+++ b/test.js
@@ -11,6 +11,14 @@
 var should = require('should');
 var matcher = require('./');
 
+it('should throw if not array, string, regexp, object or function', function () {
+  function fixture () {
+    matcher(1234)
+  }
+  should.throws(fixture, TypeError)
+  should.throws(fixture, /expects a string, array, regex, object or function/)
+})
+
 describe('should return a matching function:', function () {
   it('from an object:', function () {
     var isMatch = matcher({a: 'b'});

--- a/test.js
+++ b/test.js
@@ -20,7 +20,7 @@ it('should throw if not array, string, regexp, object or function', function () 
 })
 
 describe('should return a matching function:', function () {
-  it('from an object:', function () {
+  it('from an object', function () {
     var isMatch = matcher({a: 'b'});
 
     isMatch({a: 'b'}).should.be.true;
@@ -28,7 +28,7 @@ describe('should return a matching function:', function () {
     isMatch({e: 'f', c: 'd'}).should.be.false;
   });
 
-  it('from a string:', function () {
+  it('from a string', function () {
     var isMatch = matcher('a');
 
     isMatch('a').should.be.true;
@@ -37,36 +37,48 @@ describe('should return a matching function:', function () {
     matcher('a')('def').should.be.false;
   });
 
-  it('from a string glob pattern:', function () {
+  it('from a string glob pattern on single value', function () {
     matcher('*')('a').should.be.true;
     matcher('!b')('a').should.be.true;
     matcher('!b')('b').should.be.false;
   });
 
-  it('from a string non-glob pattern:', function () {
+  it('from a string glob pattern on multiple values', function () {
+    matcher('*')(['a', 'b']).should.be.true;
+    matcher('{(b|[A-Z]),!([C-F])}.js')(['E.js', 'a.js']).should.be.false;
+    matcher('{(b|[A-Z]),!([C-F])}.js')(['E.js', 'B.js']).should.be.true;
+  });
+
+  it('from a string non-glob pattern on single value', function () {
     matcher('abc')('foo abc bar').should.be.false;
     matcher('abc')('abc').should.be.true;
+  })
+
+  it('from a string non-glob pattern on multiple values', function () {
     matcher('abc')(['foo', 'abc']).should.be.true;
     matcher('abc')(['foo abc bar', 'baz']).should.be.true;
   });
 
-  it('from an array of glob patterns:', function () {
-    matcher(['a'])('a').should.be.false;
-    matcher(['b'])('a').should.be.false;
-    matcher(['b', 'a'])(['a', 'b']).should.be.false;
-    matcher(['b', 'a'])(['b', 'a']).should.be.true;
-    matcher(['b', 'c', '*'])(['b', 'c', '*']).should.be.true;
+  it('from an array of glob patterns on single value', function () {
+    matcher(['a', 'b'])('a').should.be.true;
+    matcher(['a', 'b'])('c').should.be.false;
     matcher(['*-koaip', '!foo-koa'])('x-koaip').should.be.true;
+  });
+
+  it('from an array of glob patterns on multiple values', function () {
+    matcher(['a', 'b'])(['a', 'c']).should.be.true;
+    matcher(['a', 'b'])(['e', 'f', 'g']).should.be.false;
+    matcher(['*-koaip', '!foo-koa'])(['x-koaip', 'bar-koa']).should.be.true;
     matcher(['*-koaip', '!foo-koa'])(['foo-koa', 'bar-koa']).should.be.false;
   });
 
-  it('from a regex:', function () {
+  it('from a regex', function () {
     var isMatch = matcher(/a/);
     isMatch('a').should.be.true;
     isMatch('b').should.be.false;
   });
 
-  it('from a function:', function () {
+  it('from a function', function () {
     var isMatch = matcher(function  (val) {
       return val === 'a';
     });

--- a/test.js
+++ b/test.js
@@ -63,6 +63,8 @@ describe('should return a matching function:', function () {
     matcher(['a', 'b'])('a').should.be.true;
     matcher(['a', 'b'])('c').should.be.false;
     matcher(['*-koaip', '!foo-koa'])('x-koaip').should.be.true;
+    matcher(['*-koaip', '!foo-koa'])('foo-koa').should.be.false;
+    matcher(['*-koaip', '!foo-koa'])('bar').should.be.false;
   });
 
   it('from an array of glob patterns on multiple values', function () {


### PR DESCRIPTION
- replace `isobject` with `is-extendable` - is that okey?
- add test for when fails
- update tests for failing use case and `non-glob string pattern`
- update description to include that it can use object as pattern
- update readme to include when pattern is object
- remove `verb` from dev deps ...? i shocked up why I waits so much, then i see verb lol 
- 100% coverage
